### PR TITLE
VS Code Refactor Workspace Settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,8 @@
+{
+    "workbench.settings.editor": "json",
+    "python.defaultInterpreterPath": "~/miniconda3/envs/mle-dev/bin/python",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    }
+}


### PR DESCRIPTION
Auto formatting settings are done in `.json` via `VS-Code` shown in `settings.json` for review (shown below)
and close  #6 

#### Python_path:
```
python.defaultInterpreterPath": "~/miniconda3/envs/mle-dev/bin/python
```
#### Auto_formatter:
```
 editor.formatOnSave": true
```
#### Sorting_Imports_on_Save:
```
editor.codeActionsOnSave": {
        "source.organizeImports": true
}
```